### PR TITLE
Adds basic livereload capability.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,10 @@
  */
 
 const express = require('express')
+const Gaze = require('gaze').Gaze
+const tinylr = require('tiny-lr')
+const path = require('path')
+const process = require('process')
 
 let fileHandlers = require('./handlers')
 
@@ -17,6 +21,14 @@ let defaultIndexRoute = require('./routes/default-index')
 let errorHandler = require('./routes/error-handler')
 
 function createApp (opts) {
+  var gaze = new Gaze(path.join(process.cwd(), '**', '*'))
+
+  var lr = require('tiny-lr')({port: 35729})
+  lr.listen()
+
+  gaze.on('ready', () => console.log('watching!'))
+  gaze.on('all', (event, fp) => lr.notifyClients([fp]))
+
   if (!opts) opts = {}
 
   // Adds your own handlers to the current handlers
@@ -29,6 +41,9 @@ function createApp (opts) {
   let app = express()
 
   app.get('/__bundle/:file.bundle.js', bundleFileRoute)
+
+  // Inject livereload snippet
+  app.use(require('connect-livereload')())
 
   fileHandlers.forEach(handler => {
     app.get(handler.extension, scriptFileRoute)

--- a/lib/template/template.html
+++ b/lib/template/template.html
@@ -9,5 +9,6 @@
     <div id="root"></div>
 
     <script src="/__bundle/<%= reqPath.replace(/\//g, '-') %>.bundle.js"></script>
+    <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -23,13 +23,17 @@
     "browserify": "^12.0.1",
     "cheerio": "^0.19.0",
     "coffeeify": "^2.0.1",
+    "connect-livereload": "^0.5.4",
     "express": "^4.13.3",
+    "gaze": "^0.5.2",
     "installify": "^1.0.2",
     "levelup": "^1.3.1",
+    "livereload-js": "^2.2.2",
     "lodash.template": "^3.6.2",
     "md5-file": "^2.0.4",
     "memdown": "^1.1.0",
     "mkdirp": "^0.5.1",
+    "tiny-lr": "^0.2.1",
     "tsify": "^0.13.1"
   }
 }


### PR DESCRIPTION
- Injects livereload client snippet into requests.
- Watches filesystem for changes under `cwd`, and triggers reload on such a change.

n.b. `gaze` does not coalesce events, so if you change a bunch of files at once, you end up notifying the clients once for each change.
